### PR TITLE
Update znc to 1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,23 @@
-FROM ubuntu:14.04
+# vim: set filetype=dockerfile :
+FROM gliderlabs/alpine
 
-RUN apt-get update && \
-    apt-get install -y znc && \
-    apt-get clean
+RUN apk-install autoconf automake gettext-dev \
+    g++ make openssl-dev pkgconfig zlib-dev \
+  && mkdir /src \
+  && cd /src \
+  && wget http://znc.in/releases/znc-1.6.0.tar.gz \
+  && tar -xzvf znc-1.6.0.tar.gz \
+  && cd znc-1.6.0 \
+  && ./configure \
+  && make \
+  && make install \
+  && cd / \
+  && rm -rf /src \
+  && apk del --purge autoconf automake gettext-dev \
+    g++ make openssl-dev pkgconfig zlib-dev \
+  && apk-install libstdc++
 
-RUN adduser --system --home /znc znc
+RUN adduser -S -h /znc znc
 
 WORKDIR /znc
 


### PR DESCRIPTION
## New Features

- Container size is ~16 MB (yay!)
- ZNC 1.6 with all the goodness that comes with it

Note that I had to change the base image from ubuntu:14.04 to gliderlabs/alpine
in order to reduce the container size down to ~16 MB.