### PR TITLE
Upgrade znc to 1.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apk-install autoconf automake gettext-dev \
     bash tzdata \
   && mkdir /src \
   && cd /src \
-  && wget http://znc.in/releases/znc-1.6.0.tar.gz \
-  && tar -xzvf znc-1.6.0.tar.gz \
-  && cd znc-1.6.0 \
+  && wget http://znc.in/releases/znc-1.6.1.tar.gz \
+  && tar -xzvf znc-1.6.1.tar.gz \
+  && cd znc-1.6.1 \
   && ./configure \
   && make \
   && make install \


### PR DESCRIPTION
I have a working container that I'm using over at [quay.io](https://quay.io/repository/marvin/docker-znc) if you'd like to kick the tires.
```
docker pull quay.io/marvin/docker-znc
```
Changelog: http://wiki.znc.in/ChangeLog/1.6.1